### PR TITLE
Quickfix unary_function

### DIFF
--- a/include/boost/container_hash/hash.hpp
+++ b/include/boost/container_hash/hash.hpp
@@ -127,7 +127,7 @@ namespace boost
         };
 #else
         template <typename T>
-        struct hash_base : std::unary_function<T, std::size_t> {};
+        struct hash_base : std::__unary_function<T, std::size_t> {};
 #endif
 
         struct enable_hash_value { typedef std::size_t type; };


### PR DESCRIPTION
We need to update boost because `unary_function` is removed from C++17.

This is a quickfix until https://github.com/maplibre/maplibre-native/pull/1660 is merged.